### PR TITLE
More complex alt list handling and exclusions

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/banstick/BanStick.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/BanStick.java
@@ -10,7 +10,6 @@ import com.programmerdan.minecraft.banstick.handler.BanStickImportHandler;
 import com.programmerdan.minecraft.banstick.handler.BanStickProxyHandler;
 import com.programmerdan.minecraft.banstick.handler.BanStickScrapeHandler;
 import com.programmerdan.minecraft.banstick.handler.BanStickTorUpdater;
-
 import vg.civcraft.mc.civmodcore.ACivMod;
 
 public class BanStick extends ACivMod {
@@ -25,20 +24,20 @@ public class BanStick extends ACivMod {
 	private BanStickScrapeHandler scrapeHandler;
 	private BanStickImportHandler importHandler;
 	private BSLog logHandler;
-	
+
 	private boolean slaveMode = false;
-	
+
 	@Override
 	public void onEnable() {
 		super.onEnable();
 
 		saveDefaultConfig();
 		reloadConfig();
-		
+
 		BanStick.instance = this;
 		connectDatabase();
 		if (!this.isEnabled()) return;
-		
+
 		if (getConfig().getBoolean("slaveMode", false)) {
 			slaveMode = true;
 		}
@@ -53,11 +52,11 @@ public class BanStick extends ACivMod {
 		registerImportHandler();
 		registerLogHandler();
 	}
-	
+
 	@Override
 	public void onDisable() {
 		super.onDisable();
-		
+
 		if (this.eventHandler != null) this.eventHandler.shutdown();
 		if (this.proxyHandler != null) this.proxyHandler.shutdown();
 		if (this.scrapeHandler != null) this.scrapeHandler.shutdown();
@@ -68,7 +67,7 @@ public class BanStick extends ACivMod {
 		if (this.logHandler != null) this.logHandler.disable();
 		if (this.databaseHandler != null) this.databaseHandler.doShutdown();
 	}
-	
+
 	private void connectDatabase() {
 		try {
 			this.databaseHandler = new BanStickDatabaseHandler(getConfig());
@@ -77,7 +76,7 @@ public class BanStick extends ACivMod {
 			this.setEnabled(false);
 		}
 	}
-	
+
 	public BanStickIPDataHandler getIPDataHandler() {
 		return this.ipdataUpdater;
 	}
@@ -85,11 +84,11 @@ public class BanStick extends ACivMod {
 	public BanStickIPHubHandler getIPHubHandler() {
 		return this.ipHubUpdater;
 	}
-	
+
 	public BanStickEventHandler getEventHandler() {
 		return this.eventHandler;
 	}
-	
+
 	private void registerCommandHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -107,9 +106,9 @@ public class BanStick extends ACivMod {
 		} catch (Exception e) {
 			this.severe("Failed to set up event capture / handling", e);
 			this.setEnabled(false);
-		}	
+		}
 	}
-	
+
 	private void registerTorHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -118,7 +117,7 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up TOR updater!", e);
 		}
 	}
-	
+
 	private void registerProxyHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -127,7 +126,7 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up Proxy updaters!", e);
 		}
 	}
-	
+
 	private void registerIPDataHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -136,7 +135,7 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up dynamic IPData updater!", e);
 		}
 	}
-	
+
 	private void registerIPHubHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -145,7 +144,7 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up dynamic IPHub.info updater!", e);
 		}
 	}
-	
+
 	private void registerScrapeHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -154,7 +153,7 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up anonymous proxy scrapers", e);
 		}
 	}
-	
+
 	private void registerImportHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -163,7 +162,7 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up data imports", e);
 		}
 	}
-	
+
 	private void registerLogHandler() {
 		if (!this.isEnabled()) return;
 		try {
@@ -173,21 +172,21 @@ public class BanStick extends ACivMod {
 			this.severe("Failed to set up ban log handler", e);
 		}
 	}
-	
+
 	public BSLog getLogHandler() {
 		return this.logHandler;
 	}
 
 	/**
-	 * 
+	 *
 	 * @return the static global instance. Not my fav pattern, but whatever.
 	 */
 	public static BanStick getPlugin() {
 		return BanStick.instance;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * @return the name of this plugin.
 	 */
 	@Override
@@ -198,9 +197,8 @@ public class BanStick extends ACivMod {
 	public void saveCache() {
 		this.databaseHandler.doShutdown();
 	}
-	
+
 	public static boolean slave() {
 		return BanStick.instance.slaveMode;
 	}
-
 }

--- a/src/main/java/com/programmerdan/minecraft/banstick/commands/GetAltsCommand.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/commands/GetAltsCommand.java
@@ -1,0 +1,54 @@
+package com.programmerdan.minecraft.banstick.commands;
+
+import com.programmerdan.minecraft.banstick.data.BSPlayer;
+import java.util.Set;
+import java.util.UUID;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class GetAltsCommand implements CommandExecutor {
+
+    public static String name = "getalts";
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length != 1) {
+            sender.sendMessage(ChatColor.RED + "You must specify a single player name or uuid");
+            return false;
+        }
+        UUID uuid = UntangleCommand.resolveName(args [0]);
+        if (uuid == null) {
+            sender.sendMessage(ChatColor.RED + "Could not parse player: " + args [0]);
+            return false;
+        }
+        BSPlayer player = BSPlayer.byUUID(uuid);
+        if (player == null) {
+            sender.sendMessage(ChatColor.RED + "Player with uuid is not known: " + uuid.toString());
+            return false;
+        }
+        Set<BSPlayer> directAssoc = player.getTransitiveSharedPlayers(true);
+        Set<BSPlayer> ignoredAssoc = player.getTransitiveSharedPlayers(false);
+        StringBuilder sb = new StringBuilder();
+        sb.append(ChatColor.GOLD + "Directly associated accounts for " + player.getName() + " are: ");
+        for(BSPlayer alt : directAssoc) {
+            sb.append(alt.getName());
+            sb.append("  ");
+        }
+        sender.sendMessage(sb.toString());
+        sb = new StringBuilder();
+        sb.append(ChatColor.GOLD + "Associated accounts split off through exclusions are: ");
+        for(BSPlayer alt : ignoredAssoc) {
+            if (directAssoc.contains(alt)) {
+                continue;
+            }
+            sb.append(alt.getName());
+            sb.append("  ");
+        }
+        sender.sendMessage(sb.toString());
+        return true;
+    }
+
+
+}

--- a/src/main/java/com/programmerdan/minecraft/banstick/commands/UntangleCommand.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/commands/UntangleCommand.java
@@ -16,8 +16,14 @@ import vg.civcraft.mc.namelayer.NameAPI;
 
 public class UntangleCommand implements CommandExecutor {
 
+    public static String name = "untangle";
+
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.RED + "You must specify player names or uuids");
+            return true;
+        }
         Set<BSPlayer> subGraphPlayers = new HashSet<>();
         Set<BSPlayer> allGraphPlayers = new HashSet<>();
         // parse uuids out of the command
@@ -81,7 +87,7 @@ public class UntangleCommand implements CommandExecutor {
         return true;
     }
 
-    private UUID resolveName(String input) {
+    public static UUID resolveName(String input) {
         UUID playerId = null;
         if (input.length() <= 16) {
             // interpret as player name

--- a/src/main/java/com/programmerdan/minecraft/banstick/commands/UntangleCommand.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/commands/UntangleCommand.java
@@ -1,0 +1,113 @@
+package com.programmerdan.minecraft.banstick.commands;
+
+import com.programmerdan.minecraft.banstick.data.BSExclusion;
+import com.programmerdan.minecraft.banstick.data.BSPlayer;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.NameAPI;
+
+public class UntangleCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        Set<BSPlayer> subGraphPlayers = new HashSet<>();
+        Set<BSPlayer> allGraphPlayers = new HashSet<>();
+        // parse uuids out of the command
+        for (String arg : args) {
+            UUID uuid = resolveName(arg);
+            if (uuid == null) {
+                sender.sendMessage(ChatColor.RED + "Could not parse player: " + arg);
+                return false;
+            }
+            subGraphPlayers.add(BSPlayer.byUUID(uuid));
+        }
+        // Determine all nodes (players) in the graph (association network) we are creating a subgraph off
+        for (BSPlayer player : subGraphPlayers) {
+            allGraphPlayers.addAll(player.getTransitiveSharedPlayers(true));
+        }
+
+        int delCounter = 0;
+        // Delete all preexisting exclusions within this graph
+        for (BSPlayer playerOuter : allGraphPlayers) {
+            for (BSPlayer playerInner : allGraphPlayers) {
+                BSExclusion excl = playerOuter.getExclusionWith(playerInner);
+                if (excl != null) {
+                    excl.delete();
+                    delCounter++;
+                }
+            }
+        }
+
+        int createCounter = 0;
+        // create exclusions between all players in the new subgraph and all players not in the new subgraph
+        Set<BSPlayer> outsideSubGraphPlayers = new HashSet<>(allGraphPlayers);
+        outsideSubGraphPlayers.removeAll(subGraphPlayers);
+        for (BSPlayer inside : subGraphPlayers) {
+            for (BSPlayer outside : outsideSubGraphPlayers) {
+                BSExclusion excl = BSExclusion.create(inside, outside);
+                inside.addExclusion(excl);
+                outside.addExclusion(excl);
+                createCounter++;
+            }
+        }
+        sender.sendMessage(ChatColor.GREEN + String.format(
+                "Added exclusions to group containing %d players. %d exclusions were created and %d exclusions were deleted",
+                allGraphPlayers.size(), createCounter, delCounter));
+        StringBuilder sb = new StringBuilder();
+        for(BSPlayer player : subGraphPlayers) {
+            sb.append(player.getName());
+            sb.append(":");
+            sb.append(player.getUUID());
+            sb.append("  ");
+        }
+        sender.sendMessage(ChatColor.GREEN + String.format("First group created contains %d players: %s", subGraphPlayers.size(), sb.toString()));
+
+        sb = new StringBuilder();
+        for(BSPlayer player : outsideSubGraphPlayers) {
+            sb.append(player.getName());
+            sb.append(":");
+            sb.append(player.getUUID());
+            sb.append("  ");
+        }
+        sender.sendMessage(ChatColor.GREEN + String.format("Second group created contains %d players: %s", outsideSubGraphPlayers.size(), sb.toString()));
+        return true;
+    }
+
+    private UUID resolveName(String input) {
+        UUID playerId = null;
+        if (input.length() <= 16) {
+            // interpret as player name
+            try {
+                return NameAPI.getUUID(input);
+            } catch (NoClassDefFoundError ncde) {
+            }
+            if (playerId == null) {
+                Player match = Bukkit.getPlayer(input);
+                if (match != null) {
+                    return match.getUniqueId();
+                } else {
+                    OfflinePlayer offPlay = Bukkit.getOfflinePlayer(input);
+                    if (offPlay != null) {
+                        return offPlay.getUniqueId();
+                    }
+                }
+            }
+        } else if (input.length() == 36) {
+            try {
+                playerId = UUID.fromString(input);
+            } catch (IllegalArgumentException iae) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusion.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusion.java
@@ -1,0 +1,249 @@
+package com.programmerdan.minecraft.banstick.data;
+
+import com.programmerdan.minecraft.banstick.BanStick;
+import com.programmerdan.minecraft.banstick.handler.BanStickDatabaseHandler;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.ChatColor;
+
+/**
+ * Represents an exclusion of association between two players.
+ *
+ * Pardoning shares will only pardon specific already existing shares, but an exclusion can be used to functionality
+ * pardon all existing and all in the future created shares between players.
+ *
+ * Exclusions can be applied even if a share does not exist yet and will be taken into account for transitive
+ * associations. Functionally players and shares form a graph in which players are nodes and shares are edges.
+ * Transitive retrievals of association groups get the biggest connected subgraph of the graph containing all
+ * players/shares. Exclusions allow specifying edges, which will be ignored during this transitive alt lookup and make
+ * them non-existant for the purpose of this graph. This allows subdividing player alt groups into subsets, which will
+ * persist even across ip changes.
+ *
+ */
+public class BSExclusion {
+
+    private static Map<Long, BSExclusion> allExclussionsID = new HashMap<>();
+
+    private long eid;
+
+    private long deferFirstPlayer;
+    private BSPlayer firstPlayer;
+    private long deferSecondPlayer;
+    private BSPlayer secondPlayer;
+
+    private Timestamp createTime;
+
+    private BSExclusion() {
+    }
+
+    public long getId() {
+        return this.eid;
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public BSPlayer getFirstPlayer() {
+        if (firstPlayer == null) {
+            firstPlayer = BSPlayer.byId(deferFirstPlayer);
+        }
+        return firstPlayer;
+    }
+
+    public long getFirstPlayerID()
+    {
+        return deferFirstPlayer;
+    }
+
+    public long getSecondPlayerID() {
+        return deferSecondPlayer;
+    }
+
+
+    public BSPlayer getSecondPlayer() {
+        if (secondPlayer == null) {
+            secondPlayer = BSPlayer.byId(deferSecondPlayer);
+        }
+        return secondPlayer;
+    }
+
+    /**
+     * Deletes this exclusion from both the cache and the database
+     */
+    public void delete() {
+        allExclussionsID.remove(this.eid);
+        try (Connection connection = BanStickDatabaseHandler.getinstanceData().getConnection();
+                PreparedStatement ps = connection.prepareStatement("DELETE * FROM bs_exclusion WHERE eid = ?");) {
+            ps.setLong(1, eid);
+            ps.execute();
+        } catch (SQLException se) {
+            BanStick.getPlugin().severe("Removal of Exclusion failed: " + eid, se);
+        }
+        getFirstPlayer().removeExclusion(this);
+        getSecondPlayer().removeExclusion(this);
+    }
+
+    public static BSExclusion byId(long eid) {
+        if (allExclussionsID.containsKey(eid)) {
+            return allExclussionsID.get(eid);
+        }
+        try (Connection connection = BanStickDatabaseHandler.getinstanceData().getConnection();
+                PreparedStatement getId = connection.prepareStatement("SELECT * FROM bs_exclusion WHERE eid = ?");) {
+            getId.setLong(1, eid);
+            try (ResultSet rs = getId.executeQuery();) {
+                if (rs.next()) {
+                    BSExclusion nS = internalGetExclusion(rs);
+                    allExclussionsID.put(eid, nS);
+                    return nS;
+                } else {
+                    BanStick.getPlugin().warning("Failed to retrieve exclusion by id: " + eid + " - not found");
+                }
+            }
+        } catch (SQLException se) {
+            BanStick.getPlugin().severe("Retrieval of Exclusion by ID failed: " + eid, se);
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieves all exclusions for a given player from the database. If some exclusions were already cached, the cached
+     * object will be priorized. The returned map will use the pid of the other player in the exclusion as key, but no
+     * guarantee can be made regarding whether the player the exclusions were requested for is the first or second
+     * player within the exclusion itself.
+     *
+     * @param player
+     *            Player to retrieve exclusions for
+     * @return Map using PID of the other player in the exclusion as key and the exclusion itself as value
+     */
+    static Map<Long, BSExclusion> byPlayer(BSPlayer player) {
+        Map<Long, BSExclusion> exclusions = new HashMap<>();
+        try (Connection connection = BanStickDatabaseHandler.getinstanceData().getConnection();
+                PreparedStatement getId = connection
+                        .prepareStatement("SELECT * FROM bs_exclusion WHERE first_pid = ? OR second_pid = ?");) {
+            getId.setLong(1, player.getId());
+            getId.setLong(2, player.getId());
+            try (ResultSet rs = getId.executeQuery();) {
+                while (rs.next()) {
+                    if (allExclussionsID.containsKey(rs.getLong(1))) {
+                        BSExclusion existingExcl = allExclussionsID.get(rs.getLong(1));
+                        long otherID = existingExcl.deferFirstPlayer == player.getId() ? existingExcl.deferSecondPlayer
+                                : existingExcl.deferFirstPlayer;
+                        exclusions.put(otherID, existingExcl);
+                        continue;
+                    }
+                    BSExclusion loadedExcl = internalGetExclusion(rs);
+                    long otherID = loadedExcl.deferFirstPlayer == player.getId() ? loadedExcl.deferSecondPlayer
+                            : loadedExcl.deferFirstPlayer;
+                    allExclussionsID.put(rs.getLong(1), loadedExcl);
+                    exclusions.put(otherID, loadedExcl);
+                }
+            }
+        } catch (SQLException se) {
+            BanStick.getPlugin().severe("Retrieval of Exclusions by Player failed: " + player.toString(), se);
+        }
+        return exclusions;
+    }
+
+    private static BSExclusion internalGetExclusion(ResultSet rs) throws SQLException {
+        BSExclusion excl = new BSExclusion();
+        excl.eid = rs.getLong(1);
+        excl.createTime = rs.getTimestamp(2);
+        excl.deferFirstPlayer = rs.getLong(3);
+        excl.deferSecondPlayer = rs.getLong(4);
+        return excl;
+    }
+
+    public static long preload(long offset, int limit) {
+        long maxId = -1;
+        try (Connection connection = BanStickDatabaseHandler.getinstanceData().getConnection();
+                PreparedStatement loadExclusions = connection
+                        .prepareStatement("SELECT * FROM bs_exclusion WHERE eid > ? ORDER BY eid LIMIT ?");) {
+            loadExclusions.setLong(1, offset);
+            loadExclusions.setInt(2, limit);
+            try (ResultSet rs = loadExclusions.executeQuery()) {
+                while (rs.next()) {
+                    if (rs.getLong(1) > maxId)
+                        maxId = rs.getLong(1);
+                    if (allExclussionsID.containsKey(rs.getLong(1))) {
+                        continue;
+                    }
+
+                    BSExclusion excl = internalGetExclusion(rs);
+                    allExclussionsID.put(excl.eid, excl);
+                }
+            }
+        } catch (SQLException se) {
+            BanStick.getPlugin().severe("Failed during Exclusion preload, offset " + offset + " limit " + limit, se);
+        }
+        return maxId;
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(ChatColor.DARK_PURPLE).append("Exclusion between ").append(ChatColor.WHITE)
+                .append(getFirstPlayer().getName()).append(ChatColor.DARK_PURPLE).append(" and ")
+                .append(ChatColor.WHITE).append(getSecondPlayer().getName());
+        return sb.toString();
+    }
+
+    public String toFullString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(ChatColor.DARK_PURPLE).append("Exclusion between ").append(ChatColor.WHITE)
+                .append(getFirstPlayer().getName()).append(ChatColor.DARK_PURPLE).append(" and ")
+                .append(ChatColor.WHITE).append(getSecondPlayer().getName()).append(ChatColor.DARK_PURPLE);
+        return sb.toString();
+    }
+
+    public static BSExclusion create(BSPlayer first, BSPlayer second) {
+        if (first == null || second == null) {
+            throw new IllegalArgumentException("Can not create exclusion based on player null");
+        }
+        try (Connection connection = BanStickDatabaseHandler.getinstanceData().getConnection();
+                PreparedStatement ps = connection.prepareStatement(
+                        "INSERT INTO bs_exclusion(create_time, first_pid, second_pid) VALUES (?, ?, ?)",
+                        Statement.RETURN_GENERATED_KEYS);) {
+            BSExclusion exclusion = new BSExclusion();
+            exclusion.createTime = new Timestamp(Calendar.getInstance().getTimeInMillis());
+            exclusion.deferFirstPlayer = first.getId();
+            exclusion.firstPlayer = first;
+            exclusion.deferSecondPlayer = second.getId();
+            exclusion.secondPlayer = second;
+
+            ps.setTimestamp(1, exclusion.createTime);
+            ps.setLong(2, exclusion.firstPlayer.getId());
+            ps.setLong(3, exclusion.secondPlayer.getId());
+            int ins = ps.executeUpdate();
+            if (ins < 1) {
+                BanStick.getPlugin().warning("Insert reported no exclusion inserted? " + exclusion.getId());
+            }
+
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    long eid = rs.getLong(1);
+                    exclusion.eid = eid;
+                    allExclussionsID.put(eid, exclusion);
+                    return exclusion;
+                } else {
+                    BanStick.getPlugin().severe(
+                            "Failed to get ID from inserted exclusion!? " + first.getId() + " - " + second.getId());
+                    return null;
+                }
+            }
+        } catch (SQLException se) {
+            BanStick.getPlugin().severe("Failed to insert new exclusion for sessions!", se);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusion.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusion.java
@@ -41,17 +41,29 @@ public class BSExclusion {
 
     private Timestamp createTime;
 
+    /**
+     * Creation only possible over the static methods
+     */
     private BSExclusion() {
     }
 
+    /**
+     * @return Unique id of this exclusion, which is also its primary key in the database
+     */
     public long getId() {
         return this.eid;
     }
 
+    /**
+     * @return When this exclusion was created
+     */
     public Date getCreateTime() {
         return createTime;
     }
 
+    /**
+     * @return First player part of this exclusion
+     */
     public BSPlayer getFirstPlayer() {
         if (firstPlayer == null) {
             firstPlayer = BSPlayer.byId(deferFirstPlayer);
@@ -59,16 +71,23 @@ public class BSExclusion {
         return firstPlayer;
     }
 
-    public long getFirstPlayerID()
-    {
+    /**
+     * @return BanStick internal id of the first player part of this exclusion
+     */
+    public long getFirstPlayerID() {
         return deferFirstPlayer;
     }
 
+    /**
+     * @return BanStick internal id of the second player part of this exclusion
+     */
     public long getSecondPlayerID() {
         return deferSecondPlayer;
     }
 
-
+    /**
+     * @return Second player part of this exclusion
+     */
     public BSPlayer getSecondPlayer() {
         if (secondPlayer == null) {
             secondPlayer = BSPlayer.byId(deferSecondPlayer);
@@ -77,7 +96,7 @@ public class BSExclusion {
     }
 
     /**
-     * Deletes this exclusion from both the cache and the database
+     * Deletes this exclusion completly from both the cache and the database
      */
     public void delete() {
         allExclussionsID.remove(this.eid);
@@ -92,6 +111,14 @@ public class BSExclusion {
         getSecondPlayer().removeExclusion(this);
     }
 
+    /**
+     * Retrieves an exclusion based on its id. If the exclusion is known in the cache it'll be loaded from there,
+     * otherwise it'll attempted to be loaded from the database
+     *
+     * @param eid
+     *            ID of the exclusion to load
+     * @return BSExclusion with the given ID or null if no such BSExclusion was found
+     */
     public static BSExclusion byId(long eid) {
         if (allExclussionsID.containsKey(eid)) {
             return allExclussionsID.get(eid);
@@ -117,7 +144,7 @@ public class BSExclusion {
 
     /**
      * Retrieves all exclusions for a given player from the database. If some exclusions were already cached, the cached
-     * object will be priorized. The returned map will use the pid of the other player in the exclusion as key, but no
+     * object will be priorized. The returned map will use the id of the other player in the exclusion as key, but no
      * guarantee can be made regarding whether the player the exclusions were requested for is the first or second
      * player within the exclusion itself.
      *
@@ -154,6 +181,14 @@ public class BSExclusion {
         return exclusions;
     }
 
+    /**
+     * Internal method to retrieve parts of a BSExclusion from a ResultSet and fill them into a new instance
+     *
+     * @param rs
+     *            ResultSet to retrieve data from
+     * @return Constructed BSExclusion
+     * @throws SQLException
+     */
     private static BSExclusion internalGetExclusion(ResultSet rs) throws SQLException {
         BSExclusion excl = new BSExclusion();
         excl.eid = rs.getLong(1);
@@ -163,6 +198,15 @@ public class BSExclusion {
         return excl;
     }
 
+    /**
+     * Preloads exclusions from the database by their index
+     *
+     * @param offset
+     *            Offset of the section to load
+     * @param limit
+     *            How many exclusions to load
+     * @return Highest id that was successfully loaded
+     */
     public static long preload(long offset, int limit) {
         long maxId = -1;
         try (Connection connection = BanStickDatabaseHandler.getinstanceData().getConnection();

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusions.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusions.java
@@ -1,0 +1,89 @@
+package com.programmerdan.minecraft.banstick.data;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+public class BSExclusions {
+
+    private BSExclusions() {
+    }
+
+    private BSPlayer forPlayer;
+
+    private List<BSExclusion> exclusionList;
+
+    public static BSExclusions onlyFor(BSPlayer player) {
+        BSExclusions exclusions = new BSExclusions();
+        return exclusions;
+    }
+
+    public List<BSExclusion> getAll() {
+        if (exclusionList == null) {
+            fill();
+        }
+        return new LinkedList<>(exclusionList);
+    }
+
+    /**
+     * @return Set containing player ids of all players this one has an exclusion with
+     */
+    public Set<Long> getExcludedPlayerIDs() {
+        Set <Long> pids = new HashSet<>();
+        for(BSExclusion excl : getAll()) {
+            pids.add(excl.getFirstPlayerID());
+            pids.add(excl.getSecondPlayerID());
+        }
+        pids.remove(forPlayer.getId());
+        return pids;
+    }
+
+    /**
+     * @return Set containing all players this one has an exclusion with
+     */
+    public Set<BSPlayer> getExcludedPlayers() {
+        Set <BSPlayer> pids = new HashSet<>();
+        for(BSExclusion excl : getAll()) {
+            pids.add(excl.getFirstPlayer());
+            pids.add(excl.getSecondPlayer());
+        }
+        pids.remove(forPlayer);
+        return pids;
+    }
+
+    public boolean hasExclusionWith(BSPlayer player) {
+        return getExclusionWith(player) != null;
+    }
+
+    public BSExclusion getExclusionWith(BSPlayer player) {
+        for (BSExclusion excl : getAll()) {
+            if (excl.getFirstPlayerID() == player.getId() || excl.getSecondPlayerID() == player.getId()) {
+                return excl;
+            }
+        }
+        return null;
+    }
+
+    public void remove(BSExclusion excl) {
+        exclusionList.remove(excl);
+    }
+
+    private void fill() {
+        exclusionList = new ArrayList<>();
+        exclusionList.addAll(BSExclusion.byPlayer(forPlayer).values());
+    }
+
+    public void addNew(BSExclusion excl) {
+        if (exclusionList == null) {
+            fill();
+        }
+        this.exclusionList.add(excl);
+
+    }
+
+    public int getOrdinality() {
+        return getAll().size();
+    }
+}

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusions.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSExclusions.java
@@ -17,6 +17,7 @@ public class BSExclusions {
 
     public static BSExclusions onlyFor(BSPlayer player) {
         BSExclusions exclusions = new BSExclusions();
+        exclusions.forPlayer = player;
         return exclusions;
     }
 

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSPlayer.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSPlayer.java
@@ -639,7 +639,7 @@ public class BSPlayer {
 
 	/**
 	 * Recursively retrieves all other BSPlayers this one has a transitive IP connection to.
-	 * For example if Player A uses IP X, Player B uses IP X & Y and Player C uses IP Y,
+	 * For example if Player A uses IP X, Player B uses IP X &amp; Y and Player C uses IP Y,
 	 * the players A and C would not have a share. This function digs recursively through shares
 	 * though to find connections like that one
 	 *

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSPlayer.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSPlayer.java
@@ -1,5 +1,7 @@
 package com.programmerdan.minecraft.banstick.data;
 
+import com.programmerdan.minecraft.banstick.BanStick;
+import com.programmerdan.minecraft.banstick.handler.BanStickDatabaseHandler;
 import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -11,30 +13,28 @@ import java.sql.Types;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
-
 import org.bukkit.entity.Player;
-
-import com.programmerdan.minecraft.banstick.BanStick;
-import com.programmerdan.minecraft.banstick.data.BSShare;
-import com.programmerdan.minecraft.banstick.handler.BanStickDatabaseHandler;
 
 /**
  * Represents player DAO logic.
- * 
+ *
  * @author <a href="mailto:programmerdan@gmail.com">ProgrammerDan</a>
  *
  */
 public class BSPlayer {
-	
-	private static Map<Long, BSPlayer> allPlayersID = new HashMap<Long, BSPlayer>();
-	private static Map<UUID, BSPlayer> allPlayersUUID = new HashMap<UUID, BSPlayer>();
-	private static ConcurrentLinkedQueue<WeakReference<BSPlayer>> dirtyPlayers = new ConcurrentLinkedQueue<WeakReference<BSPlayer>>();
+
+	private static Map<Long, BSPlayer> allPlayersID = new HashMap<>();
+	private static Map<UUID, BSPlayer> allPlayersUUID = new HashMap<>();
+	private static ConcurrentLinkedQueue<WeakReference<BSPlayer>> dirtyPlayers = new ConcurrentLinkedQueue<>();
 	private BSPlayer() {}
-	
+
 	private long pid;
 	private String name;
 	private UUID uuid;
@@ -45,63 +45,64 @@ public class BSPlayer {
 	private Timestamp proxyPardonTime;
 	private Timestamp sharedPardonTime;
 	private boolean dirty;
-	
+
 	private transient BSSessions allSessions;
 	private transient BSIPs allIPs;
 	private transient BSShares allShares;
-	
+	private transient BSExclusions allExclusions;
+
 	public long getId() {
 		return pid;
 	}
-	
+
 	public String getName() {
 		return name;
 	}
-	
+
 	public void setName(String name) {
 		this.name = name;
 		this.dirty = true;
-		dirtyPlayers.offer(new WeakReference<BSPlayer>(this));
+		dirtyPlayers.offer(new WeakReference<>(this));
 	}
-	
+
 	public UUID getUUID() {
 		return uuid;
 	}
-	
+
 	public Date getFirstAdd() {
 		return firstAdd;
 	}
-	
+
 	public Date getIPPardonTime() {
 		return ipPardonTime;
 	}
-	
+
 	public void setIPPardonTime(Date pardon) {
 		this.ipPardonTime = pardon != null ? new Timestamp(pardon.getTime()) : null;
 		this.dirty = true;
-		dirtyPlayers.offer(new WeakReference<BSPlayer>(this));
+		dirtyPlayers.offer(new WeakReference<>(this));
 	}
-	
+
 	public Date getProxyPardonTime() {
 		return proxyPardonTime;
 	}
-	
+
 	public void setProxyPardonTime(Date pardon) {
 		this.proxyPardonTime = pardon != null ? new Timestamp(pardon.getTime()) : null;
 		this.dirty = true;
-		dirtyPlayers.offer(new WeakReference<BSPlayer>(this));
+		dirtyPlayers.offer(new WeakReference<>(this));
 	}
-	
+
 	public Date getSharedPardonTime() {
 		return sharedPardonTime;
 	}
-	
+
 	public void setSharedPardonTime(Date pardon) {
 		this.sharedPardonTime = pardon != null ? new Timestamp(pardon.getTime()) : null;
 		this.dirty = true;
-		dirtyPlayers.offer(new WeakReference<BSPlayer>(this));
+		dirtyPlayers.offer(new WeakReference<>(this));
 	}
-	
+
 	public BSBan getBan() {
 		if (this.bid == null && this.deferBid != null) {
 			this.bid = BSBan.byId(this.deferBid);
@@ -120,14 +121,14 @@ public class BSPlayer {
 		this.bid = bid;
 		this.deferBid = (bid == null ? null : bid.getId());
 		this.dirty = true;
-		dirtyPlayers.offer(new WeakReference<BSPlayer>(this));
+		dirtyPlayers.offer(new WeakReference<>(this));
 
 	}
-	
+
 	/**
 	 * This is the heart of the tracking. If a session is already active, ends it; Starts a session for this player, associates that session with the current IP data,
 	 * checks for new shares and any other stuff like that.
-	 * 
+	 *
 	 * @param player The player whose session to start
 	 * @param sessionStart The Date that the session began
 	 */
@@ -141,11 +142,11 @@ public class BSPlayer {
 		latest = this.allSessions.startNew(ip, sessionStart);
 		this.allShares.check(latest);
 	}
-	
+
 	/**
 	 * If session is active, end it. Starts a new session, when IP is known.
 	 * Checks for new shares.
-	 * 
+	 *
 	 * @param ip The exact IP to use
 	 * @param sessionStart the session start time
 	 */
@@ -158,38 +159,38 @@ public class BSPlayer {
 		latest = this.allSessions.startNew(ip, sessionStart);
 		this.allShares.check(latest);
 	}
-	
+
 	/**
 	 * Ends the latest session for this player. Player-centric exposed focus for BSSessions's endLatest
-	 * 
+	 *
 	 * @param sessionEnd Date to end this player's current session.
 	 */
 	public void endSession(Date sessionEnd) {
 		this.allSessions.endLatest(sessionEnd);
 	}
-	
+
 	/**
 	 * Gets the latest session for this player.
-	 * 
+	 *
 	 * @return The latest BSSession object
 	 */
 	public BSSession getLatestSession() {
 		return this.allSessions.getLatest();
 	}
-	
+
 	/**
 	 * Gets all sessions for this player
-	 * 
+	 *
 	 * @return A list of all BSSessions for this player
 	 */
 	public List<BSSession> getAllSessions() {
 		return this.allSessions.getAll();
 	}
-	
+
 	/**
 	 * This leverages a fun queue of WeakReferences, where if a player is forcibly flush()'d we don't care, or if a player is in the queue more then once
 	 * we don't care, b/c we only save a dirty player once; and since we all store references and no copies, everything is nice and synchronized.
-	 * 
+	 *
 	 */
 	public static void saveDirty() {
 		int batchSize = 0;
@@ -226,7 +227,7 @@ public class BSPlayer {
 			BanStick.getPlugin().severe("Save of BSPlayer dirty batch failed!: ", se);
 		}
 	}
-	
+
 	/**
 	 * Saves the BSPlayer; only for internal use. Outside code must use Flush();
 	 */
@@ -244,7 +245,7 @@ public class BSPlayer {
 			BanStick.getPlugin().severe("Save of BSPlayer failed!: ", se);
 		}
 	}
-	
+
 	private void saveToStatement(PreparedStatement savePlayer) throws SQLException {
 		if (this.ipPardonTime == null) {
 			savePlayer.setNull(1,  Types.TIMESTAMP);
@@ -273,7 +274,7 @@ public class BSPlayer {
 		}
 		savePlayer.setLong(6, this.pid);
 	}
-	
+
 	/**
 	 * Cleanly saves this player if necessary, and removes it from the references lists.
 	 */
@@ -289,10 +290,10 @@ public class BSPlayer {
 		this.bid = null;
 		this.deferBid = null;
 	}
-	
+
 	/**
 	 * Create a new player from the Bukkit object
-	 * 
+	 *
 	 * @param player The player object to use
 	 * @return the BSPlayer created from the player, or null
 	 */
@@ -306,14 +307,14 @@ public class BSPlayer {
 			newPlayer.name = player.getDisplayName();
 			newPlayer.uuid = player.getUniqueId();
 			newPlayer.firstAdd = new Timestamp(Calendar.getInstance().getTimeInMillis());
-			
+
 			try (PreparedStatement insertPlayer = connection.prepareStatement("INSERT INTO bs_player(name, uuid, first_add) VALUES (?, ?, ?);", Statement.RETURN_GENERATED_KEYS)) {
 				insertPlayer.setString(1, newPlayer.name);
 				insertPlayer.setString(2, newPlayer.uuid.toString());
 				insertPlayer.setTimestamp(3, newPlayer.firstAdd);
 				insertPlayer.execute();
 				try (ResultSet rs = insertPlayer.getGeneratedKeys()) {
-					if (rs.next()) { 
+					if (rs.next()) {
 						newPlayer.pid = rs.getLong(1);
 					} else {
 						BanStick.getPlugin().severe("No PID returned on player insert?!");
@@ -321,11 +322,12 @@ public class BSPlayer {
 					}
 				}
 			}
-			
+
 			newPlayer.allSessions = BSSessions.onlyFor(newPlayer);
 			newPlayer.allIPs = BSIPs.onlyFor(newPlayer);
 			newPlayer.allShares = BSShares.onlyFor(newPlayer);
-			
+			newPlayer.allExclusions = BSExclusions.onlyFor(newPlayer);
+
 			allPlayersID.put(newPlayer.pid, newPlayer);
 			allPlayersUUID.put(newPlayer.uuid, newPlayer);
 			return newPlayer;
@@ -334,7 +336,7 @@ public class BSPlayer {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Get player by UUID, pull from DB if not cached already.
 	 * @param uuid Gets a BSPlayer record by uuid.
@@ -360,6 +362,7 @@ public class BSPlayer {
 						player = new BSPlayer();
 						player.pid = pid;
 						player.allSessions = BSSessions.onlyFor(player);
+						player.allExclusions = BSExclusions.onlyFor(player);
 						player.allIPs = BSIPs.onlyFor(player);
 						player.allShares = BSShares.onlyFor(player);
 					}
@@ -401,10 +404,10 @@ public class BSPlayer {
 		}
 		return null; //TODO: exception
 	}
-	
+
 	/**
 	 * Direct lookup for a BSPlayer by database ID
-	 * 
+	 *
 	 * @param pid The Player ID to use in the lookup
 	 * @return The Player found, or null if not found
 	 */
@@ -424,6 +427,7 @@ public class BSPlayer {
 					player.dirty = false;
 					player.pid = pid;
 					player.allSessions = BSSessions.onlyFor(player);
+					player.allExclusions = BSExclusions.onlyFor(player);
 					player.allIPs = BSIPs.onlyFor(player);
 					player.allShares = BSShares.onlyFor(player);
 					player.name = rs.getString(2);
@@ -463,7 +467,7 @@ public class BSPlayer {
 		}
 		return null; // TODO: exception
 	}
-	
+
 	public static BSPlayer create(UUID playerId) {
 		return null;
 	}
@@ -478,7 +482,7 @@ public class BSPlayer {
 			newPlayer.name = name;
 			newPlayer.uuid = playerId;
 			newPlayer.firstAdd = new Timestamp(Calendar.getInstance().getTimeInMillis());
-			
+
 			try (PreparedStatement insertPlayer = connection.prepareStatement("INSERT INTO bs_player(name, uuid, first_add) VALUES (?, ?, ?);", Statement.RETURN_GENERATED_KEYS)) {
 				if (newPlayer.name == null) {
 					insertPlayer.setNull(1, Types.VARCHAR);
@@ -489,7 +493,7 @@ public class BSPlayer {
 				insertPlayer.setTimestamp(3, newPlayer.firstAdd);
 				insertPlayer.execute();
 				try (ResultSet rs = insertPlayer.getGeneratedKeys()) {
-					if (rs.next()) { 
+					if (rs.next()) {
 						newPlayer.pid = rs.getLong(1);
 					} else {
 						BanStick.getPlugin().severe("No PID returned on player insert?!");
@@ -497,11 +501,12 @@ public class BSPlayer {
 					}
 				}
 			}
-			
+
 			newPlayer.allSessions = BSSessions.onlyFor(newPlayer);
 			newPlayer.allIPs = BSIPs.onlyFor(newPlayer);
 			newPlayer.allShares = BSShares.onlyFor(newPlayer);
-			
+			newPlayer.allExclusions = BSExclusions.onlyFor(newPlayer);
+
 			allPlayersID.put(newPlayer.pid, newPlayer);
 			allPlayersUUID.put(newPlayer.uuid, newPlayer);
 			return newPlayer;
@@ -510,10 +515,10 @@ public class BSPlayer {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Preloads a segment of player data. Offset indicates lowbound exclusive to begin, with limit constraining size of batch.
-	 * 
+	 *
 	 * @param offset (not included) low bound on ID of record to load.
 	 * @param limit how many to load
 	 * @return last ID encountered, or -1 is none/no more
@@ -561,11 +566,12 @@ public class BSPlayer {
 					} catch (SQLException te) {
 						player.sharedPardonTime = null;
 					}
-					
+
 					player.allSessions = BSSessions.onlyFor(player);
 					player.allIPs = BSIPs.onlyFor(player);
 					player.allShares = BSShares.onlyFor(player);
-					
+					player.allExclusions = BSExclusions.onlyFor(player);
+
 					if (!allPlayersID.containsKey(player.pid)) {
 						allPlayersID.put(player.pid, player);
 					}
@@ -579,7 +585,7 @@ public class BSPlayer {
 		}
 		return maxId;
 	}
-	
+
 	@Override
 	public String toString() {
 		StringBuffer sb = new StringBuffer();
@@ -600,29 +606,29 @@ public class BSPlayer {
 	}
 
 	public void pardonShare(BSShare share) {
-		this.allShares.markPardoned(share);		
+		this.allShares.markPardoned(share);
 	}
-	
+
 	public void unpardonShare(BSShare share) {
 		this.allShares.markUnpardoned(share);
 	}
-	
+
 	public int getUnpardonedShareCardinality() {
 		return this.allShares.unpardonedOrdinality();
 	}
-	
+
 	public int getTotalShareCardinality() {
 		return this.allShares.shareOrdinality();
 	}
-	
+
 	public BSShare getLatestShare() {
 		return this.allShares.getLatest();
 	}
-	
+
 	public List<BSShare> getUnpardonedShares() {
 		return this.allShares.getUnpardoned();
 	}
-	
+
 	public List<BSShare> sharesWith(BSPlayer player) {
 		if (this.allShares.doesShareWith(player.getId())) {
 			return this.allShares.getSharesWith(player);
@@ -631,11 +637,58 @@ public class BSPlayer {
 		}
 	}
 
+	/**
+	 * Recursively retrieves all other BSPlayers this one has a transitive IP connection to.
+	 * For example if Player A uses IP X, Player B uses IP X & Y and Player C uses IP Y,
+	 * the players A and C would not have a share. This function digs recursively through shares
+	 * though to find connections like that one
+	 *
+	 * @param respectExclusions Whether player specific exclusions should be taken into account to ignore specific connections
+	 *
+	 * @return Set containing all BSPlayer this one has transitive ip association with
+	 */
+	public Set<BSPlayer> getTransitiveSharedPlayers(boolean respectExclusions) {
+	   return getTransitiveSharedPlayersRecursive(new HashSet<BSPlayer>(), respectExclusions);
+	}
+
+	private Set <BSPlayer> getTransitiveSharedPlayersRecursive(Set <BSPlayer> alts, boolean respectExclusions) {
+	    alts.add(this);
+	    for(BSShare share : getAllShares()) {
+	        if (share.isPardoned()) {
+	            continue;
+	        }
+	        if (!alts.contains(share.getFirstPlayer()) && !(respectExclusions && allExclusions.hasExclusionWith(share.getFirstPlayer()))) {
+	            share.getFirstPlayer().getTransitiveSharedPlayersRecursive(alts, respectExclusions);
+	        }
+	        if (!alts.contains(share.getSecondPlayer()) && !(respectExclusions && allExclusions.hasExclusionWith(share.getSecondPlayer()))) {
+                share.getSecondPlayer().getTransitiveSharedPlayersRecursive(alts, respectExclusions);
+            }
+	    }
+	    return alts;
+	}
+
 	public List<BSShare> getAllShares() {
 		return this.allShares.getAll();
 	}
 
 	public void addShare(BSShare share, BSPlayer player) {
 		this.allShares.addNew(share, player);
+	}
+
+	public void addExclusion(BSExclusion excl) {
+	    this.allExclusions.addNew(excl);
+	}
+
+	public void removeExclusion(BSExclusion excl) {
+	    this.allExclusions.remove(excl);
+	}
+
+	public BSExclusion getExclusionWith(BSPlayer player) {
+	    return allExclusions.getExclusionWith(player);
+	}
+
+	@Override
+    public int hashCode() {
+	    return Objects.hash(getId());
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickCommandHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickCommandHandler.java
@@ -1,7 +1,5 @@
 package com.programmerdan.minecraft.banstick.handler;
 
-import org.bukkit.configuration.file.FileConfiguration;
-
 import com.programmerdan.minecraft.banstick.BanStick;
 import com.programmerdan.minecraft.banstick.commands.BanSaveCommand;
 import com.programmerdan.minecraft.banstick.commands.BanStickCommand;
@@ -9,21 +7,24 @@ import com.programmerdan.minecraft.banstick.commands.DoubleTapCommand;
 import com.programmerdan.minecraft.banstick.commands.DowsingRodCommand;
 import com.programmerdan.minecraft.banstick.commands.DrillDownCommand;
 import com.programmerdan.minecraft.banstick.commands.ForgiveCommand;
+import com.programmerdan.minecraft.banstick.commands.GetAltsCommand;
 import com.programmerdan.minecraft.banstick.commands.LoveTapCommand;
 import com.programmerdan.minecraft.banstick.commands.TakeItBackCommand;
+import com.programmerdan.minecraft.banstick.commands.UntangleCommand;
+import org.bukkit.configuration.file.FileConfiguration;
 
 /**
  * Handles Commands for this plugin. Check plugin.yml for details!
- * 
+ *
  * @author <a href="mailto:programmerdan@gmail.com">ProgrammerDan</a>
  *
  */
 public class BanStickCommandHandler {
-	
+
 	public BanStickCommandHandler(FileConfiguration config) {
 		registerCommands();
 	}
-	
+
 	private void registerCommands() {
 		BanStick.getPlugin().getCommand(BanStickCommand.name).setExecutor(new BanStickCommand());
 		BanStick.getPlugin().getCommand(DoubleTapCommand.name).setExecutor(new DoubleTapCommand());
@@ -33,6 +34,8 @@ public class BanStickCommandHandler {
 		BanStick.getPlugin().getCommand(TakeItBackCommand.name).setExecutor(new TakeItBackCommand());
 		BanStick.getPlugin().getCommand(DowsingRodCommand.name).setExecutor(new DowsingRodCommand());
 		BanStick.getPlugin().getCommand(DrillDownCommand.name).setExecutor(new DrillDownCommand());
+		BanStick.getPlugin().getCommand(UntangleCommand.name).setExecutor(new UntangleCommand());
+		BanStick.getPlugin().getCommand(GetAltsCommand.name).setExecutor(new GetAltsCommand());
 	}
 
 }

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickDatabaseHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickDatabaseHandler.java
@@ -1,50 +1,47 @@
 package com.programmerdan.minecraft.banstick.handler;
 
+import com.programmerdan.minecraft.banstick.BanStick;
+import com.programmerdan.minecraft.banstick.data.BSBan;
+import com.programmerdan.minecraft.banstick.data.BSIP;
+import com.programmerdan.minecraft.banstick.data.BSIPData;
+import com.programmerdan.minecraft.banstick.data.BSLog;
+import com.programmerdan.minecraft.banstick.data.BSPlayer;
+import com.programmerdan.minecraft.banstick.data.BSSession;
+import com.programmerdan.minecraft.banstick.data.BSShare;
 import java.net.InetAddress;
 import java.util.List;
 import java.util.UUID;
-
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
-
-import com.programmerdan.minecraft.banstick.BanStick;
-import com.programmerdan.minecraft.banstick.data.BSBan;
-import com.programmerdan.minecraft.banstick.data.BSIP;
-import com.programmerdan.minecraft.banstick.data.BSPlayer;
-import com.programmerdan.minecraft.banstick.data.BSSession;
-import com.programmerdan.minecraft.banstick.data.BSShare;
-import com.programmerdan.minecraft.banstick.data.BSIPData;
-import com.programmerdan.minecraft.banstick.data.BSLog;
-
 import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
 
 /**
  * Ties into the managed datasource processes of the CivMod core plugin.
- * 
+ *
  * @author <a href="mailto:programmerdan@gmail.com">ProgrammerDan</a>
  *
  */
 public class BanStickDatabaseHandler {
 
 	private ManagedDatasource data;
-	
+
 	public ManagedDatasource getData() {
 		return this.data;
 	}
-	
+
 	private static BanStickDatabaseHandler instance;
-	
+
 	public static BanStickDatabaseHandler getInstance() {
 		return BanStickDatabaseHandler.instance;
 	}
-	
+
 	public static ManagedDatasource getinstanceData() {
 		return BanStickDatabaseHandler.instance.data;
 	}
-	
+
 	public BanStickDatabaseHandler(FileConfiguration config) {
 		if (!configureData(config.getConfigurationSection("database"))) {
 			throw new RuntimeException("Failed to configure Database for BanStick!");
@@ -71,9 +68,9 @@ public class BanStickDatabaseHandler {
 			return false;
 		}
 
-		initializeTables();		
+		initializeTables();
 		stageUpdates();
-		
+
 		long begin_time = System.currentTimeMillis();
 
 		try {
@@ -88,7 +85,7 @@ public class BanStickDatabaseHandler {
 		}
 
 		BanStick.getPlugin().info(String.format("Database update took %d seconds", (System.currentTimeMillis() - begin_time) / 1000));
-		
+
 		activatePreload(config.getConfigurationSection("preload"));
 		activateDirtySave(config.getConfigurationSection("dirtysave"));
 		return true;
@@ -102,7 +99,7 @@ public class BanStickDatabaseHandler {
 			delay = config.getLong("delay", delay);
 		}
 		BanStick.getPlugin().debug("DirtySave Period {0} Delay {1}", period, delay);
-		
+
 		Bukkit.getScheduler().runTaskTimerAsynchronously(BanStick.getPlugin(), new Runnable() {
 			@Override
 			public void run() {
@@ -118,7 +115,7 @@ public class BanStickDatabaseHandler {
 				BSBan.saveDirty();
 			}
 		}, delay + (period / 5), period);
-		
+
 		Bukkit.getScheduler().runTaskTimerAsynchronously(BanStick.getPlugin(), new Runnable() {
 			@Override
 			public void run() {
@@ -155,9 +152,9 @@ public class BanStickDatabaseHandler {
 				delay = config.getLong("delay", delay);
 			}
 			final int batchsize = config.getInt("batch", 100);
-			
+
 			BanStick.getPlugin().debug("Preload Period {0} Delay {1} batch {2}", period, delay, batchsize);
-			
+
 			new BukkitRunnable() {
 				private long lastId = 0l;
 				@Override
@@ -167,7 +164,7 @@ public class BanStickDatabaseHandler {
 					if (lastId < 0) this.cancel();
 				}
 			}.runTaskTimerAsynchronously(BanStick.getPlugin(), delay, period);
-			
+
 			new BukkitRunnable() {
 				private long lastId = 0l;
 				@Override
@@ -177,7 +174,7 @@ public class BanStickDatabaseHandler {
 					if (lastId < 0) this.cancel();
 				}
 			}.runTaskTimerAsynchronously(BanStick.getPlugin(), delay + (period / 6), period);
-			
+
 			new BukkitRunnable() {
 				private long lastId = 0l;
 				@Override
@@ -187,7 +184,7 @@ public class BanStickDatabaseHandler {
 					if (lastId < 0) this.cancel();
 				}
 			}.runTaskTimerAsynchronously(BanStick.getPlugin(), delay + ((period * 2) / 6), period);
-			
+
 			new BukkitRunnable() {
 				private long lastId = 0l;
 				@Override
@@ -207,7 +204,7 @@ public class BanStickDatabaseHandler {
 					if (lastId < 0) this.cancel();
 				}
 			}.runTaskTimerAsynchronously(BanStick.getPlugin(), delay + ((period * 4) / 6), period);
-			
+
 			new BukkitRunnable() {
 				private long lastId = 0l;
 				@Override
@@ -220,14 +217,14 @@ public class BanStickDatabaseHandler {
 		} else {
 			BanStick.getPlugin().info("Preloading is disabled. Expect more lag on joins, lookups, and bans.");
 		}
-		
+
 	}
 
 	/**
 	 * Basic method to set up data model v1.
 	 */
 	private void initializeTables() {
-		data.registerMigration(0,  false, 
+		data.registerMigration(0,  false,
 					"CREATE TABLE IF NOT EXISTS bs_player (" +
 					" pid BIGINT AUTO_INCREMENT PRIMARY KEY," +
 					" name VARCHAR(16)," +
@@ -301,7 +298,7 @@ public class BanStickDatabaseHandler {
 					" iid BIGINT NOT NULL REFERENCES bs_ip(iid)," +
 					" create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP," +
 					" valid BOOLEAN DEFAULT TRUE," +
-					" continent TEXT," + 
+					" continent TEXT," +
 					" country TEXT," +
 					" region TEXT," +
 					" city TEXT," +
@@ -314,22 +311,29 @@ public class BanStickDatabaseHandler {
 					" connection TEXT," +
 					" proxy FLOAT," +
 					" source TEXT," +
-					" comment TEXT," + 
+					" comment TEXT," +
 					" INDEX bs_ip_data_iid (iid)," +
 					" INDEX bs_ip_data_valid (valid, create_time DESC)," +
 					" INDEX bs_ip_data_proxy (proxy)" +
 					");"
 				);
-		
+		data.registerMigration(1,  false, "CREATE TABLE IF NOT EXISTS bs_exclusion ("
+		        + "eid BIGINT AUTO_INCREMENT PRIMARY KEY,"
+	            + "create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                + "first_pid BIGINT NOT NULL REFERENCES bs_player(pid),"
+                + "second_pid BIGINT NOT NULL REFERENCES bs_player(pid),"
+                + " INDEX bs_exclusion_pid (first_pid, second_pid),"
+		        + ");");
+
 	}
-	
+
 	/**
 	 * Add all new migrations here.
 	 */
 	private void stageUpdates() {
-		
+
 	}
-	
+
 	public void doShutdown() {
 
 		BanStick.getPlugin().info("Player dirty save");
@@ -346,28 +350,28 @@ public class BanStickDatabaseHandler {
 
 		BanStick.getPlugin().info("Proxy dirty save");
 		BSIPData.saveDirty();
-		
+
 		BanStick.getPlugin().info("Ban Log save");
 		BSLog log = BanStick.getPlugin().getLogHandler();
 		if (log != null) log.disable();
 	}
-	
+
 	// ============ QUERIES =============
-	
+
 	public BSPlayer getOrCreatePlayer(final Player player) {
 		// TODO: use exception
 		BSPlayer bsPlayer = getPlayer(player.getUniqueId());
 		if (bsPlayer == null) {
 			bsPlayer = BSPlayer.create(player);
 		}
-		
+
 		return bsPlayer;
 	}
-	
+
 	public BSPlayer getPlayer(final UUID uuid) {
 		return BSPlayer.byUUID(uuid); // TODO: exception
 	}
-	
+
 	public BSIP getOrCreateIP(final InetAddress netAddress) {
 		BSIP bsIP = getIP(netAddress);
 		if (bsIP == null) {
@@ -379,11 +383,11 @@ public class BanStickDatabaseHandler {
 		}
 		return bsIP;
 	}
-	
+
 	public BSIP getIP(final InetAddress netAddress) {
 		return BSIP.byInetAddress(netAddress);
 	}
-	
+
 	public List<BSIP> getAllByIP(final InetAddress netAddress) {
 		return BSIP.allMatching(netAddress);
 	}

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickDatabaseHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickDatabaseHandler.java
@@ -65,6 +65,7 @@ public class BanStickDatabaseHandler {
 			data.getConnection().close();
 		} catch (Exception se) {
 			BanStick.getPlugin().info("Failed to initialize Database connection");
+			se.printStackTrace();
 			return false;
 		}
 
@@ -319,10 +320,10 @@ public class BanStickDatabaseHandler {
 				);
 		data.registerMigration(1,  false, "CREATE TABLE IF NOT EXISTS bs_exclusion ("
 		        + "eid BIGINT AUTO_INCREMENT PRIMARY KEY,"
-	            + "create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+	            + "create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
                 + "first_pid BIGINT NOT NULL REFERENCES bs_player(pid),"
                 + "second_pid BIGINT NOT NULL REFERENCES bs_player(pid),"
-                + " INDEX bs_exclusion_pid (first_pid, second_pid),"
+                + " INDEX bs_exclusion_pid (first_pid, second_pid)"
 		        + ");");
 
 	}

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
@@ -107,7 +107,7 @@ public class BanStickEventHandler implements Listener {
 				}
 			}
 			if (transitiveBans) {
-			    for(BSPlayer alt : player.getTransitiveSharedPlayers()) {
+			    for(BSPlayer alt : player.getTransitiveSharedPlayers(true)) {
 			        ban = alt.getBan();
 		            if (ban != null) {
 		                if (ban.getBanEndTime() != null && ban.getBanEndTime().before(new Date())) { // ban has ended.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -61,6 +61,7 @@ log:
 #   - proxyKicks: If banstick should autokick players for existing, standing banable proxies (does not issue ban)
 #   - proxyBans: If banstick should autoban players for existing, standing bans of known proxies (enable proxyKicks to also kick)
 #   - newProxyBans: If banstick should check the proxy threshold and create new bans for proxies if non already exists (leave true even if only kicking)
+#   - transitiveBans: If banstick should apply bans transitive across IPs
 #   Usage notes: To ban AND kick on new proxy detection, turn on proxyKicks, proxyBans, and newProxyBans.
 #                To ban but not kick, turn on proxyBans, and newProxyBans.
 #                To kick but not ban, turn on proxyKicks and newProxyBans.
@@ -82,6 +83,7 @@ events:
   proxyBans: true
   newProxyBans: true
   shareBans: true
+  transitiveBans: true
 # Configure the data source for VPS / VPN proxy list grabs.
 # For cloud9:
 #  ban.length is in millisecond

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -92,6 +92,18 @@ commands:
   alias: bsbs
   permission: banstick.ips
   usage: /<command>
+ untangle:
+  description: Reassigns alt groups
+  permission: banstick.alts.modify
+  usage: |
+   /<command> [name/uuid] [name/uuid] [name/uuid] ...
+     Merges all of these accounts into a new alt group
+ getalts:
+  description: Gets alts for a player
+  permission: banstick.alts.view
+  usage: |
+   /<command> <name/uuid>
+     Gets alts for this account
 permissions:
  banstick.ban:
   description: Allows delivery of justice
@@ -105,6 +117,16 @@ permissions:
  banstick.ips:
   description: Allows full investigation of all data
   default: op
+ banstick.alts.view:
+  description: Allows viewing player alts
+  default: op
+ banstick.alts.modify:
+  description: Allows viewing player alts
+  default: op
+ banstick.alts:
+  children:
+   banstick.alts.modify: true
+   banstick.alts.view: true
  banstick.*:
   description: Superpowered justice
   default: op
@@ -113,3 +135,4 @@ permissions:
    banstick.lovetap: true
    banstick.forgive: true
    banstick.ips: true
+   banstick.alts: true


### PR DESCRIPTION
First of all, this isn't ready for merging yet, I need to read over it again, add more docu and test it. That being said, it's probably far enough to at least get some thoughts regarding the approach in general.

BanStick seems to have been built around Devoteds single account policy. While it supports more than one account per player, it's handling of player association groups is not powerful enough to deal with the situation that multi accounting servers bring with them.

For example:

Player A plays on IP1, Player B plays on IP1 and IP2, Player C plays on IP2.

It's likely that Player A and C are the same person or at least ip sharing in a way that should be trackable. In the current system they do not have a share though and there is no direct way to find their connection, likely it would go unnoticed forever.

The solution here is to do a recursive lookup through shares to retrieves not only direct shares, but also transitive ones to create alt groups. Basically we're doing graph theory here, players are nodes and shares are edges. To determine alt groups, we are finding the biggest fully connected subgraph containing a given player. An additional config option allows limiting both bans and the account number limitation not only based on shares, but these transitive alt groups.

In an ideal world we'd be done here, but sadly we have to deal with players who use each others account/computer/VPN and get all mixed up in ways they shouldnt be.

Banstick already offers pardoning shares to combat this, but when dealing with situations where we have to assign n different accounts to m players each, pardoned shares are too weak of a concept to solve this problem, especially because new ones may be created in the future, for example when people play in the same house on dynamic ips.

To deal with this, I decided to introduce the concept of exclusions, which are like the opposite of a share. They contain 2 players and specify an edge in the graph, which will be assumed nonexistent when trying to find the alt group subgraph. To create an exclusion, a share between the two players doesnt even have to exist yet though.

Admins are supposed to simply give a list of accounts which make up a real player via command and BanStick will create exclusions to cut all of those accounts out of the alt group they are currently in and create their own little pocket.

As you might have already noticed, the usage and kind of the thought behind it is heavily inspired by MiscLog's approach.